### PR TITLE
Remove hotkey return from bind

### DIFF
--- a/Conductor/ConfigLoader.m
+++ b/Conductor/ConfigLoader.m
@@ -128,7 +128,6 @@ static NSString *const ConfigPath = @"~/.conductor.js";
         }];
         [self.hotkeys addObject:hotkey];
         [hotkey enable];
-        return hotkey;
     };
 
     api[@"runCommand"] = ^(NSString *path, NSArray *args) {


### PR DESCRIPTION
This never should have been returned, it can't be used by the callers.
It seems that the JS engine crashes because this value leaks or
something.