### PR TITLE
Remove parameter from reload API

### DIFF
--- a/Conductor/ConfigLoader.m
+++ b/Conductor/ConfigLoader.m
@@ -104,7 +104,7 @@ static NSString *const ConfigPath = @"~/.conductor.js";
     JSValue *api = [JSValue valueWithNewObjectInContext:ctx];
     ctx[@"api"] = api;
 
-    api[@"reload"] = ^void(NSString *str) {
+    api[@"reload"] = ^void {
         [self reload];
     };
 


### PR DESCRIPTION
This reloads everything anyways, no reason to take a path.